### PR TITLE
repo-def/dasharo.yaml: add heads and mrchromebox edk2 fork

### DIFF
--- a/repo-def/dasharo.yaml
+++ b/repo-def/dasharo.yaml
@@ -1,4 +1,6 @@
 coreboot: "https://review.coreboot.org/coreboot.git"
 flashrom: "https://review.coreboot.org/flashrom.git"
 fwupd: "https://github.com/fwupd/fwupd.git"
+heads: "https://github.com/linuxboot/heads.git"
+mrchromebox-edk2: "https://github.com/mrchromebox/edk2.git"
 seabios: "https://review.coreboot.org/seabios.git"


### PR DESCRIPTION
Not sure about adding a fork of edk2 instead of the upstream, but I do have a contribution there that wasn't sent upstream.